### PR TITLE
Add Trace-PSDetourProcess and store detoured info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for PSDetour
 
+## v0.3.0 - TBD
+
+* Added `Trace-PSDetourProcess` to make it easier to start hooks for auditing in other processes
+  * This provides a common mechanism that can be used to output data from a remote hook as well as wait for input data in the hook itself
+* Provides a `DetouredModules` property in the hooks `$this` variable
+  * This provides access to other detoured method's InvokeContext allowing the hook to call the underlying API
+* Remove separate parameter sets for `New-PSDetourHook`
+  * A breaking change is that `DllName` and `MethodName` must be specified with `Address` now
+* Added option `-AddressIsOffset` to specify `-Address` is located at the offset of the `-DllName` when loaded in the process
+
 ## v0.2.0 - 2023-04-18
 
 * Added `-Address` parameter to `New-PSDetourHook` to hook a method at a specific address offset rather than by name.

--- a/docs/en-US/New-PSDetourHook.md
+++ b/docs/en-US/New-PSDetourHook.md
@@ -13,14 +13,9 @@ Create a PSDetour hook from a scriptblock.
 
 ## SYNTAX
 
-### Name (Default)
 ```
-New-PSDetourHook [-DllName] <String> [-MethodName] <String> [-Action] <ScriptBlock> [<CommonParameters>]
-```
-
-### Address
-```
-New-PSDetourHook -Address <IntPtr> [-Action] <ScriptBlock> [<CommonParameters>]
+New-PSDetourHook [-DllName] <String> [-MethodName] <String> [-Action] <ScriptBlock> [-Address <IntPtr>]
+ [-AddressIsOffset] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -113,13 +108,31 @@ Accept wildcard characters: False
 ### -Address
 Hook the method at the address specified.
 This can be used to hook methods that are not publicly exported by name.
+The `-DllName` and `-MethodName` must still be set to provide enough metadata for the reflected method to be generated.
+By default the `Address` is the offset in the current process but `-AddressIsOffset` can be used to specify the address is an offset from the loaded `DllName` address of the process.
 
 ```yaml
 Type: IntPtr
-Parameter Sets: Address
+Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AddressIsOffset
+Will automatically calculated the actual method address from the loaded Dll module specified by `-DllName` based on the `-Address` value.
+For example if `Kernel32.dll` is loaded at the address `0x0000F000` and the specified address is `-Address 0x0001`, the final method address will be `0x0000F001`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -132,7 +145,7 @@ The DLL name or path where the C function to hook is defined.
 
 ```yaml
 Type: String
-Parameter Sets: Name
+Parameter Sets: (All)
 Aliases:
 
 Required: True
@@ -148,7 +161,7 @@ The C function name/symbol to hook.
 
 ```yaml
 Type: String
-Parameter Sets: Name
+Parameter Sets: (All)
 Aliases:
 
 Required: True

--- a/docs/en-US/PSDetour.md
+++ b/docs/en-US/PSDetour.md
@@ -23,3 +23,6 @@ Starts a detour session.
 ### [Stop-PSDetour](Stop-PSDetour.md)
 Stops a PSDetour session and removes all active hooks.
 
+### [Trace-PSDetourProcess](Trace-PSDetourProcess.md)
+Starts a PSDetour hook in either the current process or specified process and provides hook helpers for getting data back.
+

--- a/docs/en-US/Trace-PSDetourProcess.md
+++ b/docs/en-US/Trace-PSDetourProcess.md
@@ -1,0 +1,174 @@
+---
+external help file: PSDetour.dll-Help.xml
+Module Name: PSDetour
+online version: https://github.com/jborean93/PSDetour/blob/main/docs/en-US/New-PSDetourHook.md
+schema: 2.0.0
+---
+
+# Trace-PSDetourProcess
+
+## SYNOPSIS
+Starts a PSDetour hook in either the current process or specified process and provides hook helpers for getting data back.
+
+## SYNTAX
+
+```
+Trace-PSDetourProcess [-Hook] <DetourHook[]> [-ProcessId <ProcessIntString>] [-FunctionsToDefine <IDictionary>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Can be used to easily start a hook session in the same or other process.
+The trace will stay alive until the target process has ended or a pipeline stop has been signaled through ctrl+c.
+The hook actions will have access to a special helper state that can be used to stream data back to the `Trace-PSDetourProcess` caller's cmdlet like `WriteObject`, `WriteVerbose`, etc.
+Keep in mind these objects will be serialized so should only be used for simple objects that are sent back to the caller.
+It also provides some PSHost integrations like `WriteLine` to write to the cmdlet's host.
+
+See [PSDetour-Hooks](https://github.com/jborean93/PSDetour-Hooks) for a collection of hooks that are designed to be used with this cmdlet.
+
+## EXAMPLES
+
+### Example 1 - Hook API in current process
+```powershell
+PS C:\> $hook = New-PSDetourHook -DllName Kernel32 -MethodName GetCurrentProcessId {
+...     [OutputType([int])]
+...     param()
+...     $this.Invoke()
+... }
+PS C:\> $hook | Trace-PSDetourProcess
+```
+
+This hooks `GetCurrentProcessId` in the current process and will wait until `ctrl+c` is pressed.
+
+### Example 2 - Hook API in another process
+```powershell
+PS C:\> $hook = New-PSDetourHook -DllName Kernel32 -MethodName GetCurrentProcessId {
+...     [OutputType([int])]
+...     param()
+...     $this.Invoke()
+... }
+PS C:\> $hook | Trace-PSDetourProcess -ProcessId lsass
+```
+
+This hooks `GetCurrentProcessId` in the target process called `lsass` and will wait until `ctrl+c` is pressed.
+
+### Example 3 - Writing output back to the caller
+```powershell
+PS C:\> $hook = New-PSDetourHook -DllName Kernel32 -MethodName GetCurrentProcessId {
+...     [OutputType([int])]
+...     param()
+...
+...     $this.State.WriteObject(@{foo = 'bar'})
+...     $this.Invoke()
+... }
+PS C:\> $hook | Trace-PSDetourProcess
+```
+
+Will write the hashtable to the output pipeline of `Trace-PSDetourProcess` whenever the hooked method is called.
+Other functions like `WriteVerbose`, `WriteLine`, `ReadLine` can be used on the `State` object, see [about_PSDetour](./about_PSDetour.md) for more information on what these methods are and what they can do.
+
+### Example 4 - Stopping trace in hook
+
+```powershell
+PS C:\> $hook = New-PSDetourHook -DllName Kernel32 -MethodName GetCurrentProcessId {
+...     [OutputType([int])]
+...     param()
+...
+...     $this.Invoke()
+...     $this.State.StopTrace()
+... }
+PS C:\> $hook | Trace-PSDetourProcess
+```
+
+Hooks the first `GetCurrentProcessId` call and stops the trace once called.
+
+### Example 5 - Define common functions
+
+```powershell
+PS C:\> Function My-Function {
+...     "output"
+... }
+PS C:\> $hook = New-PSDetourHook -DllName Kernel32 -MethodName GetCurrentProcessId {
+...     [OutputType([int])]
+...     param()
+...
+...     Set-Item -Path Function:My-Function -Value $this.State.GetFunction("My-Function")
+...     $this.State.WriteObject((My-Function))
+...
+...     $this.Invoke()
+... }
+PS C:\> $hook | Trace-PSDetourProcess -FunctionsToDefine @{"My-Function" = ${function:My-Function}}
+```
+
+Registers the function `My-Function` which can be redefined in the hook scope through `$this.State.GetFunction`.
+The function can then be called just like any other PowerShell function.
+
+## PARAMETERS
+
+### -FunctionsToDefine
+Common functions to define that the `$this.State` will have access to in the hook.
+These function scriptblocks can be access through `$this.State.GetFunction("Function-Name").
+
+```yaml
+Type: IDictionary
+Parameter Sets: (All)
+Aliases: Functions
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Hook
+The hooks to load in the target process.
+
+```yaml
+Type: DetourHook[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ProcessId
+The target process to trace as either the process id, process name, or process object.
+If a process name is used and multiple processes are found with that name, the cmdlet will output an error.
+If not specified, the current process will be traced.
+
+```yaml
+Type: ProcessIntString
+Parameter Sets: (All)
+Aliases: Process
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### PSDetour.DetourHook[]
+The hook as input by value or by name.
+
+## OUTPUTS
+
+### System.Object
+Any objects output by the hook's `State` object will be output here. These objects will be serialized so will not be "live" and will be a snapshot of the object that was sent from the hook.
+
+## NOTES
+See [PSDetour-Hooks](https://github.com/jborean93/PSDetour-Hooks) for a collection of various APIs that have been written to be used with this cmdlet.
+
+## RELATED LINKS
+
+[PSDetour-Hooks](https://github.com/jborean93/PSDetour-Hooks)

--- a/module/PSDetour.psd1
+++ b/module/PSDetour.psd1
@@ -14,7 +14,7 @@
     RootModule        = 'PSDetour.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.2.0'
+    ModuleVersion     = '0.3.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -73,6 +73,7 @@
         'New-PSDetourSession'
         'Start-PSDetour'
         'Stop-PSDetour'
+        'Trace-PSDetourProcess'
     )
 
     # Variables to export from this module

--- a/src/PSDetour/Commands/PSDetour.cs
+++ b/src/PSDetour/Commands/PSDetour.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 

--- a/src/PSDetour/Commands/PSDetourHook.cs
+++ b/src/PSDetour/Commands/PSDetourHook.cs
@@ -3,53 +3,37 @@ using System.Management.Automation;
 
 namespace PSDetour.Commands;
 
-[Cmdlet(VerbsCommon.New, "PSDetourHook", DefaultParameterSetName = "Name")]
+[Cmdlet(VerbsCommon.New, "PSDetourHook")]
 [OutputType(typeof(ScriptBlockHook))]
 public class NewPSDetourHook : PSCmdlet
 {
     [Parameter(
         Mandatory = true,
-        Position = 1,
-        ParameterSetName = "Name"
+        Position = 1
     )]
     public string DllName { get; set; } = "";
 
     [Parameter(
         Mandatory = true,
-        Position = 2,
-        ParameterSetName = "Name"
+        Position = 2
     )]
     public string MethodName { get; set; } = "";
 
     [Parameter(
         Mandatory = true,
-        Position = 1,
-        ParameterSetName = "Address"
-    )]
-    public IntPtr Address { get; set; } = IntPtr.Zero;
-
-    [Parameter(
-        Mandatory = true,
-        Position = 3,
-        ParameterSetName = "Name"
-    )]
-    [Parameter(
-        Mandatory = true,
-        Position = 2,
-        ParameterSetName = "Address"
+        Position = 3
     )]
     [Alias("ScriptBlock")]
     public ScriptBlock Action { get; set; } = default!;
 
+    [Parameter]
+    public IntPtr Address { get; set; } = IntPtr.Zero;
+
+    [Parameter]
+    public SwitchParameter AddressIsOffset { get; set; }
+
     protected override void EndProcessing()
     {
-        if (ParameterSetName == "Address")
-        {
-            WriteObject(new ScriptBlockHook(Address, Action));
-        }
-        else
-        {
-            WriteObject(new ScriptBlockHook(DllName, MethodName, Action));
-        }
+        WriteObject(new ScriptBlockHook(DllName, MethodName, Action, Address, AddressIsOffset));
     }
 }

--- a/src/PSDetour/Commands/TracePSDetourProcess.cs
+++ b/src/PSDetour/Commands/TracePSDetourProcess.cs
@@ -1,0 +1,513 @@
+using Microsoft.Win32.SafeHandles;
+using PSDetour.Native;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PSDetour.Commands;
+
+[Cmdlet(VerbsDiagnostic.Trace, "PSDetourProcess")]
+public sealed class TracePSDetourProcessCommand : PSCmdlet
+{
+    private CancellationTokenSource? _cancelToken;
+    private List<Dictionary<string, object>> _hooks = new();
+
+    [Parameter(
+        Mandatory = true,
+        Position = 0,
+        ValueFromPipeline = true,
+        ValueFromPipelineByPropertyName = true
+    )]
+    [ValidateNotNullOrEmpty]
+    public DetourHook[] Hook { get; set; } = Array.Empty<DetourHook>();
+
+    [Parameter]
+    [Alias("Process")]
+    public ProcessIntString? ProcessId { get; set; }
+
+    [Parameter]
+    [Alias("Functions")]
+    public IDictionary? FunctionsToDefine { get; set; }
+
+    protected override void ProcessRecord()
+    {
+        foreach (DetourHook h in Hook)
+        {
+            if (h is ScriptBlockHook sbkHook)
+            {
+                _hooks.Add(new Dictionary<string, object>()
+                {
+                    { "Action", sbkHook.Action.ToString() },
+                    { "Address", sbkHook.Address.ToInt64() },
+                    { "AddressIsOffset", sbkHook.AddressIsOffset },
+                    { "DllName", sbkHook.DllName },
+                    { "MethodName", sbkHook.MethodName },
+                });
+            }
+            else
+            {
+                ErrorRecord err = new(
+                    new ArgumentException("Can only use ScriptBlockHooks with Trace-ProcessApi"),
+                    "HookNotScriptBlock",
+                    ErrorCategory.InvalidArgument,
+                    null
+                );
+                WriteError(err);
+            }
+        }
+    }
+
+    protected override void EndProcessing()
+    {
+        using AnonymousPipeServerStream readPipe = new(PipeDirection.In, HandleInheritability.None);
+        using AnonymousPipeServerStream writePipe = new(PipeDirection.Out, HandleInheritability.None);
+
+        using CancellationTokenSource cancelToken = new();
+        _cancelToken = cancelToken;
+
+        const ProcessAccessRights dupRights = ProcessAccessRights.DupHandle;
+        using SafeProcessHandle currentProces = Kernel32.GetCurrentProcess();
+        SafeProcessHandle targetProcess;
+
+        Runspace? rs = null;
+        SafeHandle targetReader;
+        SafeHandle targetWriter;
+        if (ProcessId == null)
+        {
+            // InitialSessionState iss = InitialSessionState.CreateDefault2();
+            // iss.ImportPSModule(new[] { GlobalState.ModulePath });
+            // rs = RunspaceFactory.CreateRunspace(Host, iss);
+            // // rs = RunspaceFactory.CreateRunspace(Host);
+            // rs.Open();
+
+            // using PowerShell ps = PowerShell.Create();
+            // ps.Runspace = rs;
+            // ps.AddCommand("Import-Module")
+            //     .AddParameter("Name", GlobalState.ModulePath)
+            //     .AddParameter("Global", true);
+            // ps.Invoke();
+
+            targetProcess = currentProces;
+            targetReader = writePipe.ClientSafePipeHandle;
+            targetWriter = readPipe.ClientSafePipeHandle;
+        }
+        else
+        {
+            rs = DetouredRunspace.Create(
+                ProcessId.ProcessObj,
+                host: Host,
+                cancelToken: _cancelToken?.Token
+            );
+
+            targetProcess = Kernel32.OpenProcess(
+                ProcessId.ProcessObj.Id,
+                dupRights,
+                false);
+            targetReader = Kernel32.DuplicateHandle(
+                currentProces,
+                writePipe.ClientSafePipeHandle,
+                targetProcess,
+                0,
+                false,
+                DuplicateHandleOptions.SameAccess,
+                true);
+            writePipe.DisposeLocalCopyOfClientHandle();
+            targetWriter = Kernel32.DuplicateHandle(
+                currentProces,
+                readPipe.ClientSafePipeHandle,
+                targetProcess,
+                0,
+                false,
+                DuplicateHandleOptions.SameAccess,
+                true);
+            readPipe.DisposeLocalCopyOfClientHandle();
+        }
+
+        // WriteVerbose("test");
+        // WriteObject(5);
+
+        using (targetProcess)
+        using (rs)
+        using (targetReader)
+        using (targetWriter)
+        {
+            Trace(
+                rs,
+                readPipe,
+                writePipe,
+                targetReader,
+                targetWriter,
+                cancelToken.Token
+            );
+        }
+    }
+
+    protected override void StopProcessing()
+    {
+        _cancelToken?.Cancel();
+    }
+
+    private void Trace(
+        Runspace? rs,
+        AnonymousPipeServerStream readPipe,
+        AnonymousPipeServerStream writePipe,
+        SafeHandle targetReader,
+        SafeHandle targetWriter,
+        CancellationToken cancelToken
+    )
+    {
+        PowerShell ps = PowerShell.Create();
+        ps.Runspace = rs;
+        ps.AddScript(@"
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [object[]]
+    $Hooks,
+
+    [Parameter(Mandatory)]
+    [Int64]
+    $ReadPipeId,
+
+    [Parameter(Mandatory)]
+    [Int64]
+    $WritePipeId,
+
+    [Parameter()]
+    [System.Collections.IDictionary]
+    $FunctionsToDefine
+)
+
+$ErrorActionPreference = 'Stop'
+
+$reader = [System.IO.Pipes.AnonymousPipeClientStream]::new(
+    [System.IO.Pipes.PipeDirection]::In,
+    [Microsoft.Win32.SafeHandles.SafePipeHandle]::new([IntPtr]$ReadPipeId, $false)
+)
+$writer = [System.IO.Pipes.AnonymousPipeClientStream]::new(
+    [System.IO.Pipes.PipeDirection]::Out,
+    [Microsoft.Win32.SafeHandles.SafePipeHandle]::new([IntPtr]$WritePipeId, $false)
+)
+
+$state = [PSDetour.Commands.TraceState]::new($reader, $writer, $FunctionsToDefine)
+
+[PSDetour.ScriptBlockHook[]]$processedHooks = @(foreach($h in $Hooks) {
+    $address = [IntPtr]::Zero
+    if ($h.Address) {
+        $address = [IntPtr]$h.Address
+    }
+    $newHook = [PSDetour.ScriptBlockHook]::new(
+        $h.DllName,
+        $h.MethodName,
+        [ScriptBlock]::Create($h.Action),
+        $address,
+        $h.AddressIsOffset
+    )
+    $newHook.SetHostContext($Host, $state)
+    $newHook
+})
+
+[PSDetour.Hook]::Start($processedHooks)
+");
+
+        ps.AddParameters(new Dictionary<string, object?>() {
+            { "Hooks", _hooks },
+            { "ReadPipeId", targetReader.DangerousGetHandle().ToInt64() },
+            { "WritePipeId", targetWriter.DangerousGetHandle().ToInt64() },
+            { "FunctionsToDefine", FunctionsToDefine },
+        });
+        try
+        {
+            ps.Invoke();
+        }
+        catch (Exception e)
+        {
+            ErrorRecord err = new(
+                e,
+                "TraceInvokeError",
+                ErrorCategory.NotSpecified,
+                null
+            );
+            err.ErrorDetails = new ErrorDetails($"Failed to start trace session: {e.Message}");
+            WriteError(err);
+            return;
+        }
+
+        bool doCleanup = true;
+        try
+        {
+            while (cancelToken.IsCancellationRequested != true)
+            {
+                // It will be disposed outside the function.
+                using StreamWriter writer = new(writePipe, new UTF8Encoding(), -1, true);
+
+                PipeMessageType messageType;
+                string? data;
+                try
+                {
+                    (messageType, data) = ReadPipe(readPipe, cancelToken);
+                }
+                catch (TaskCanceledException)
+                {
+                    return;
+                }
+
+                if (data == null)
+                {
+                    // The pipe has been closed which means the process has
+                    // ended. We want to avoid trying to cleanup the handles in
+                    // that other process as it will have been ended.
+                    if (targetReader is SafeDuplicateHandle)
+                    {
+                        targetReader.SetHandleAsInvalid();
+                    }
+                    if (targetWriter is SafeDuplicateHandle)
+                    {
+                        targetWriter.SetHandleAsInvalid();
+                    }
+                    doCleanup = false;
+                    break;
+                }
+                else if (messageType == PipeMessageType.Stop)
+                {
+                    break;
+                }
+
+                ProcessPipeMessage(messageType, data, writer);
+            }
+        }
+        finally
+        {
+            if (doCleanup)
+            {
+                ps = PowerShell.Create();
+                ps.Runspace = rs;
+                ps.AddScript("[PSDetour.Hook]::Stop()").Invoke();
+            }
+        }
+    }
+
+    private void ProcessPipeMessage(PipeMessageType messageType, string data, StreamWriter writer)
+    {
+        switch (messageType)
+        {
+            case PipeMessageType.Output:
+                WriteObject(PSSerializer.Deserialize(data));
+                break;
+            case PipeMessageType.Error:
+                PSObject errObj = (PSObject)PSSerializer.Deserialize(data);
+                ErrorRecord err = (ErrorRecord)ReflectionInfo.ErrorRecordFromPSObject.Invoke(
+                    null, new[] { errObj })!;
+                WriteError(err);
+                break;
+            case PipeMessageType.Verbose:
+                WriteVerbose(data);
+                break;
+            case PipeMessageType.Warning:
+                WriteWarning(data);
+                break;
+            case PipeMessageType.Debug:
+                WriteDebug(data);
+                break;
+            case PipeMessageType.Information:
+                PSObject infoObj = (PSObject)PSSerializer.Deserialize(data);
+                InformationRecord info = (InformationRecord)ReflectionInfo.InformationRecordFromPSObject.Invoke(
+                    null, new[] { infoObj })!;
+                WriteInformation(info);
+                break;
+            case PipeMessageType.Progress:
+                ProgressRecord prog = (ProgressRecord)PSSerializer.Deserialize(data);
+                WriteProgress(prog);
+                break;
+            case PipeMessageType.WriteLine:
+                Host?.UI?.WriteLine(data);
+                break;
+            case PipeMessageType.ReadLine:
+                string? response = null;
+                try
+                {
+                    response = Host?.UI?.ReadLine();
+                }
+                catch (Exception e)
+                {
+                    // If in non-interactive mode it will raise an exception,
+                    // ensure a response is sent back to avoid it being
+                    // blocked.
+                    response = e.Message;
+                }
+
+                writer.WriteLine(response ?? "");
+                break;
+        }
+    }
+
+    private static (PipeMessageType, string?) ReadPipe(PipeStream pipe, CancellationToken cancelToken)
+    {
+        PipeMessageType messageType = PipeMessageType.Stop;
+
+        byte[] lengthBuffer = new byte[8];
+        if (!TryReadPipeRaw(pipe, lengthBuffer, cancelToken))
+        {
+            return (messageType, null);
+        }
+
+        messageType = (PipeMessageType)BitConverter.ToInt32(lengthBuffer, 0);
+        int dataLength = BitConverter.ToInt32(lengthBuffer, 4);
+        byte[] buffer = new byte[dataLength];
+
+        if (!TryReadPipeRaw(pipe, buffer, cancelToken))
+        {
+            return (messageType, null);
+        }
+
+        return (messageType, Encoding.UTF8.GetString(buffer));
+    }
+
+    private static bool TryReadPipeRaw(PipeStream pipe, byte[] data, CancellationToken cancelToken)
+    {
+        int offset = 0;
+        int length = data.Length;
+        while (offset < length)
+        {
+            Task<int> readTask = pipe.ReadAsync(data, offset, length - offset, cancelToken);
+            int read = readTask.WaitAsync(cancelToken).ConfigureAwait(false).GetAwaiter().GetResult();
+            if (read == 0)
+            {
+                return false;
+            }
+            offset += read;
+        }
+
+        return true;
+    }
+}
+
+internal enum PipeMessageType
+{
+    Stop,
+    Output,
+    Error,
+    Verbose,
+    Warning,
+    Debug,
+    Information,
+    Progress,
+    WriteLine,
+    ReadLine
+}
+
+public sealed class TraceState
+{
+    private Encoding _utf8 = new UTF8Encoding();
+    private StreamReader _reader;
+    private AnonymousPipeClientStream _writer;
+    private Dictionary<string, ScriptBlock> _functions = new();
+
+    public TraceState(AnonymousPipeClientStream reader, AnonymousPipeClientStream writer, IDictionary? functions)
+    {
+        _reader = new StreamReader(reader, _utf8);
+        _writer = writer;
+
+        if (functions != null)
+        {
+            foreach (DictionaryEntry entry in functions)
+            {
+                string functionName = entry.Key.ToString() ?? "";
+                ScriptBlock functionDef = ScriptBlock.Create(entry.Value?.ToString() ?? "");
+                _functions[functionName] = functionDef;
+            }
+        }
+    }
+
+    public ScriptBlock GetFunction(string function)
+    {
+        return _functions[function];
+    }
+
+    public void WriteDebug(string text)
+    {
+        WritePipe(text, PipeMessageType.Debug);
+    }
+
+    public void WriteError(ErrorRecord errorRecord)
+    {
+        string errorClixml = PSSerializer.Serialize(errorRecord);
+        WritePipe(errorClixml, PipeMessageType.Error);
+    }
+
+    public void WriteInformation(InformationRecord informationRecord)
+    {
+        string informationClixml = PSSerializer.Serialize(informationRecord);
+        WritePipe(informationClixml, PipeMessageType.Information);
+    }
+
+    public void WriteObject(object sendToPipeline) => WriteObject(sendToPipeline, 1);
+
+    public void WriteObject(object sendToPipeline, int depth)
+    {
+        string objectClixml = PSSerializer.Serialize(sendToPipeline, depth);
+        WritePipe(objectClixml, PipeMessageType.Output);
+    }
+
+    public void WriteProgress(ProgressRecord progressRecord)
+    {
+        string progressClixml = PSSerializer.Serialize(progressRecord);
+        WritePipe(progressClixml, PipeMessageType.Progress);
+    }
+
+    public void WriteVerbose(string text)
+    {
+        WritePipe(text, PipeMessageType.Verbose);
+    }
+
+    public void WriteWarning(string text)
+    {
+        WritePipe(text, PipeMessageType.Warning);
+    }
+
+    public void WriteLine() => WriteLine("");
+
+    public void WriteLine(string line, params string[] arg)
+    {
+        string formattedLine = string.Format(line, arg);
+        WritePipe(formattedLine, PipeMessageType.WriteLine);
+    }
+
+    public string ReadLine() => ReadLine(null);
+
+    public string ReadLine(string? prompt)
+    {
+        if (!string.IsNullOrEmpty(prompt))
+        {
+            WriteLine(prompt);
+        }
+
+        WritePipe("", PipeMessageType.ReadLine);
+        return _reader.ReadLine() ?? "";
+    }
+
+    public void StopTrace()
+    {
+        WritePipe("", PipeMessageType.Stop);
+    }
+
+    private void WritePipe(string data, PipeMessageType messageType)
+    {
+        byte[] rawData = _utf8.GetBytes(data);
+
+        Span<byte> typeLength = stackalloc byte[8];
+        BitConverter.TryWriteBytes(typeLength, (int)messageType);
+        BitConverter.TryWriteBytes(typeLength[4..], rawData.Length);
+        _writer.Write(typeLength);
+        _writer.Write(rawData, 0, rawData.Length);
+        _writer.Flush();
+    }
+}

--- a/src/PSDetour/DetouredRunspace.cs
+++ b/src/PSDetour/DetouredRunspace.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Management.Automation.Runspaces;
+using System.Text;
+using System.Threading;
+
+namespace PSDetour;
+
+internal sealed class DetouredRunspace
+{
+    private ManualResetEvent? _openEvent = null;
+    private Runspace _runspace;
+
+    private DetouredRunspace(Runspace runspace)
+    {
+        _runspace = runspace;
+    }
+
+    internal void Open(CancellationToken? cancelToken)
+    {
+        using (_openEvent = new ManualResetEvent(false))
+        {
+            using CancellationTokenRegistration? tokenRegister = cancelToken?.Register(() => SetOpenEvent());
+            _runspace.StateChanged += HandleRunspaceStateChanged;
+            _runspace.OpenAsync();
+            _openEvent?.WaitOne();
+
+            if (_runspace.RunspaceStateInfo.State == RunspaceState.Broken)
+            {
+                throw _runspace.RunspaceStateInfo.Reason;
+            }
+        }
+    }
+
+    private void HandleRunspaceStateChanged(object? source, RunspaceStateEventArgs stateEventArgs)
+    {
+        switch (stateEventArgs.RunspaceStateInfo.State)
+        {
+            case RunspaceState.Opened:
+            case RunspaceState.Closed:
+            case RunspaceState.Broken:
+                if (_runspace != null)
+                {
+                    _runspace.StateChanged -= HandleRunspaceStateChanged;
+                }
+
+                SetOpenEvent();
+                break;
+        }
+    }
+
+    private void SetOpenEvent()
+    {
+        try
+        {
+            _openEvent?.Set();
+        }
+        catch (ObjectDisposedException) { }
+    }
+
+    public static Runspace Create(
+        Process process,
+        PSPrimitiveDictionary? applicationArguments = null,
+        PSHost? host = null,
+        string? name =  null,
+        int timeoutMs = 5000,
+        CancellationToken? cancelToken = null
+    )
+    {
+        string pipeName = GetProcessPipeName(process);
+        if (Directory.GetFiles(@"\\.\pipe\", pipeName).Length < 1)
+        {
+            DetouredProcess.InjectPowerShell(process.Id, timeoutMs, GlobalState.PwshAssemblyDir);
+        }
+
+        NamedPipeConnectionInfo connInfo = new(pipeName, timeoutMs);
+
+        Runspace rs = RunspaceFactory.CreateRunspace(
+            connInfo,
+            host,
+            TypeTable.LoadDefaultTypeFiles(),
+            applicationArguments,
+            name: name);
+        new DetouredRunspace(rs).Open(cancelToken);
+
+        using PowerShell ps = PowerShell.Create();
+        ps.Runspace = rs;
+        ps.AddCommand("Import-Module")
+            .AddParameter("Name", GlobalState.ModulePath)
+            .AddParameter("Global", true);
+        ps.Invoke();
+
+        return rs;
+    }
+
+    private static string GetProcessPipeName(Process proc)
+    {
+        // This is the same logic used in pwsh internally
+        StringBuilder pipeNameBuilder = new();
+        pipeNameBuilder.Append("PSHost.")
+            .Append(proc.StartTime.ToFileTime().ToString(CultureInfo.InvariantCulture))
+            .Append('.')
+            .Append(proc.Id.ToString(CultureInfo.InvariantCulture))
+            .Append(".DefaultAppDomain.")
+            .Append(proc.ProcessName);
+
+        return pipeNameBuilder.ToString();
+    }
+}

--- a/src/PSDetour/OnImportAndRemove.cs
+++ b/src/PSDetour/OnImportAndRemove.cs
@@ -12,6 +12,13 @@ internal static class GlobalState
 {
     internal static SafeLoadedLibrary? _nativePSDetour = null;
 
+    public static string ModulePath = Path.GetFullPath(Path.Combine(
+        typeof(GlobalState).Assembly.Location,
+        "..",
+        "..",
+        "..",
+        "PSDetour.psd1"));
+
     public static string NativePath { get; } = Path.GetFullPath(Path.Combine(
         Path.GetDirectoryName(typeof(GlobalState).Assembly.Location) ?? "",
         "..",
@@ -24,7 +31,7 @@ internal static class GlobalState
 
     public static Dictionary<string, SafeLoadedLibrary> LoadedLibraries { get; } = new(StringComparer.OrdinalIgnoreCase);
 
-    public static IntPtr GetProcAddress(string library, string method)
+    public static IntPtr GetModuleHandle(string library)
     {
         IntPtr modHandle;
         try
@@ -41,6 +48,12 @@ internal static class GlobalState
             modHandle = LoadedLibraries[library].DangerousGetHandle();
         }
 
+        return modHandle;
+    }
+
+    public static IntPtr GetProcAddress(string library, string method)
+    {
+        IntPtr modHandle = GetModuleHandle(library);
         return Kernel32.GetProcAddress(modHandle, method);
     }
 

--- a/src/PSDetour/RemoteWorker.cs
+++ b/src/PSDetour/RemoteWorker.cs
@@ -1,10 +1,7 @@
 using Microsoft.Win32.SafeHandles;
 using System;
-using System.IO;
 using System.IO.Pipes;
-using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Runtime.Loader;
 using System.Text;
 
 namespace PSDetour;

--- a/tests/TracePSDetourProcess.Tests.ps1
+++ b/tests/TracePSDetourProcess.Tests.ps1
@@ -1,0 +1,738 @@
+. ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+
+Describe "Trace-PSDetourProcess" {
+    It "Traces current process" {
+        $hook = New-PSDetourHook -DllName Kernel32.dll -MethodName Sleep -Action {
+            param([int]$Milliseconds)
+
+            $this.State.WriteObject($Milliseconds)
+        }
+
+        $modulePath = Join-Path (Get-Module -Name PSDetour).ModuleBase 'PSDetour.psd1'
+
+        $ps = [PowerShell]::Create()
+        $null = $ps.AddScript({
+            param($ModulePath, $Hook)
+
+            Import-Module $ModulePath -ErrorAction Stop
+
+            "started"
+            $Hook | Trace-PSDetourProcess
+        }).AddParameters(@{ModulePath = $modulePath; Hook = $hook})
+
+        $inputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $outputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $null = Register-ObjectEvent -InputObject $outputStream -EventName DataAdded -SourceIdentifier PSDetourAdded
+        try {
+            $psi = [System.Management.Automation.PSInvocationSettings]@{
+                Host = $Host
+            }
+            $task = $ps.BeginInvoke($inputStream, $outputStream, $psi, $null, $null)
+
+            # Waits until started has been written
+            Wait-Event -SourceIdentifier PSDetourAdded | Remove-Event
+
+            # Add a second padding for the trace to actually start
+            Start-Sleep -Second 1
+            [PSDetourTest.Native]::Sleep(5)
+
+            $dataAdded = Wait-Event -SourceIdentifier PSDetourAdded -Timeout 5
+            if (-not $dataAdded) {
+                throw "timeout waiting for trace output"
+            }
+            $actual = $outputStream[$dataAdded.SourceEventArgs[0].Index]
+
+            $ps.Stop()
+            try {
+                $ps.EndInvoke($task)
+            }
+            catch [System.Management.Automation.PipelineStoppedException] {}
+        }
+        finally {
+            Remove-Event -SourceIdentifier PSDetourAdded -ErrorAction SilentlyContinue
+            Unregister-Event -SourceIdentifier PSDetourAdded
+        }
+
+        $actual | Should -Be 5
+    }
+
+    It "Traces current process with outputs" {
+        $hook = New-PSDetourHook -DllName Kernel32.dll -MethodName Sleep -Action {
+            param([int]$Milliseconds)
+
+            $this.State.WriteDebug("debug")
+            $this.State.WriteError([System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]"Exception",
+                "ErrorId",
+                "NotSpecified",
+                $null
+            ))
+            $this.State.WriteInformation([System.Management.Automation.InformationRecord]::new(
+                "object",
+                "source"
+            ))
+            $this.State.WriteProgress([System.Management.Automation.ProgressRecord]::new(
+                1,
+                "activity",
+                "description"
+            ))
+            $this.State.WriteVerbose("verbose")
+            $this.State.WriteWarning("warning")
+            $this.State.WriteLine()
+            $this.State.WriteLine("line")
+            $res1 = $this.State.ReadLine()
+            $this.State.WriteLine($res1)
+            $res2 = $this.State.ReadLine("readline prompt")
+            $this.State.WriteLine($res2)
+            $this.State.WriteObject($Milliseconds)
+        }
+
+        $modulePath = Join-Path (Get-Module -Name PSDetour).ModuleBase 'PSDetour.psd1'
+
+        $ps = [PowerShell]::Create()
+        $null = $ps.AddScript({
+            param($ModulePath, $Hook)
+
+            Import-Module $ModulePath -ErrorAction Stop
+
+            "started"
+            $Hook | Trace-PSDetourProcess -Debug -Verbose -WarningAction Continue
+        }).AddParameters(@{ModulePath = $modulePath; Hook = $hook})
+
+        $inputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $outputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $null = Register-ObjectEvent -InputObject $outputStream -EventName DataAdded -SourceIdentifier PSDetourAdded
+        try {
+            $customHost = [PSDetourTest.Host]::new($Host)
+            $psi = [System.Management.Automation.PSInvocationSettings]@{
+                Host = $customHost
+            }
+            $task = $ps.BeginInvoke($inputStream, $outputStream, $psi, $null, $null)
+
+            # Waits until started has been written
+            Wait-Event -SourceIdentifier PSDetourAdded | Remove-Event
+
+            # Add a second padding for the trace to actually start
+            Start-Sleep -Second 1
+            [PSDetourTest.Native]::Sleep(5)
+
+            $dataAdded = Wait-Event -SourceIdentifier PSDetourAdded -Timeout 5
+            if (-not $dataAdded) {
+                throw "timeout waiting for trace output"
+            }
+            $actual = $outputStream[$dataAdded.SourceEventArgs[0].Index]
+
+            $ps.Stop()
+            try {
+                $ps.EndInvoke($task)
+            }
+            catch [System.Management.Automation.PipelineStoppedException] {}
+        }
+        finally {
+            Remove-Event -SourceIdentifier PSDetourAdded -ErrorAction SilentlyContinue
+            Unregister-Event -SourceIdentifier PSDetourAdded
+        }
+
+        $actual | Should -Be 5
+        $ps.Streams.Error.Count | Should -Be 1
+        $ps.Streams.Error[0].ToString() | Should -Be Exception
+        $ps.Streams.Progress.Count | Should -Be 1
+        $ps.Streams.Progress[0].ActivityId | Should -Be 1
+        $ps.Streams.Progress[0].Activity | Should -Be activity
+        $ps.Streams.Progress[0].StatusDescription | Should -Be description
+        $ps.Streams.Verbose.Count | Should -Be 1
+        $ps.Streams.Verbose[0].ToString() | Should -Be verbose
+        $ps.Streams.Debug.Count | Should -Be 1
+        $ps.Streams.Debug[0].ToString() | Should -Be debug
+        $ps.Streams.Warning.Count | Should -Be 1
+        $ps.Streams.Warning[0].ToString() | Should -Be warning
+        $ps.Streams.Information.Count | Should -Be 1
+        $ps.Streams.Information[0].MessageData | Should -Be object
+        $ps.Streams.Information[0].Source | Should -Be source
+
+        $customHost.UI.WriteCalls.WriteLine.Count | Should -Be 5
+        $customHost.UI.WriteCalls.WriteLine[0] | Should -Be ''
+        $customHost.UI.WriteCalls.WriteLine[1] | Should -Be line
+        $customHost.UI.WriteCalls.WriteLine[2] | Should -Be 'readline response'
+        $customHost.UI.WriteCalls.WriteLine[3] | Should -Be 'readline prompt'
+        $customHost.UI.WriteCalls.WriteLine[4] | Should -Be 'readline response'
+    }
+
+    It "Traces other process" {
+        $proc = $waitEvent1 = $waitEvent2 = $null
+        $registeredEvent = $false
+        $eventName = [Guid]::NewGuid().Guid
+
+        try {
+            $waitEvent1 = [System.Threading.EventWaitHandle]::new(
+                $false,
+                [System.Threading.EventResetMode]::ManualReset,
+                "Global\$eventName-1")
+            $waitEvent2 = [System.Threading.EventWaitHandle]::new(
+                $false,
+                [System.Threading.EventResetMode]::ManualReset,
+                "Global\$eventName-2")
+
+            $procScript = {
+                $ErrorActionPreference = 'Stop'
+
+                $commonPath = 'REPLACE_COMMON_PATH'
+                .$commonPath
+
+                $eventName = 'REPLACE_EVENT_NAME'
+                $waitEvent1 = [System.Threading.EventWaitHandle]::OpenExisting("Global\$eventName-1")
+                $waitEvent2 = [System.Threading.EventWaitHandle]::OpenExisting("Global\$eventName-2")
+                try {
+                    $waitEvent1.Set()
+                    if (-not $waitEvent2.WaitOne(5000)) {
+                        throw "Timed out waiting to start"
+                    }
+                    [PSDetourTest.Native]::Sleep(5)
+                }
+                finally {
+                    $waitEvent1.Dispose()
+                    $waitEvent2.Dispose()
+                }
+
+                "Done"
+                Start-Sleep -Seconds 60
+            }.ToString() -replace 'REPLACE_EVENT_NAME', $eventName -replace 'REPLACE_COMMON_PATH', ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+            $encCommand = [System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($procScript))
+
+            $procParams = @{
+                FilePath = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+                ArgumentList = "-NoProfile -NonInteractive -EncodedCommand $encCommand"
+                PassThru = $true
+                WindowStyle = 'Hidden'
+            }
+            $proc = Start-Process @procParams
+
+            $hook = New-PSDetourHook -DllName Kernel32.dll -MethodName Sleep -Action {
+                param([int]$Milliseconds)
+
+                $this.State.WriteObject($Milliseconds)
+            }
+
+            $modulePath = Join-Path (Get-Module -Name PSDetour).ModuleBase 'PSDetour.psd1'
+
+            $ps = [PowerShell]::Create()
+            $null = $ps.AddScript({
+                param($ModulePath, $Hook, $Process)
+
+                Import-Module $ModulePath -ErrorAction Stop
+
+                "started"
+                $Hook | Trace-PSDetourProcess -ProcessId $Process
+            }).AddParameters(@{ModulePath = $modulePath; Hook = $hook; Process = $proc})
+
+            $inputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+            $outputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+            Register-ObjectEvent -InputObject $outputStream -EventName DataAdded -SourceIdentifier PSDetourAdded
+            $registeredEvent = $true
+            $psi = [System.Management.Automation.PSInvocationSettings]@{
+                Host = $host
+            }
+
+            if (-not $waitEvent1.WaitOne(5000)) {
+                throw "timed out waiting for child process to be ready"
+            }
+            $task = $ps.BeginInvoke($inputStream, $outputStream, $psi, $null, $null)
+
+            # Waits until started has been written
+            Wait-Event -SourceIdentifier PSDetourAdded | Remove-Event
+
+            # Add a second padding for the trace to actually start
+            Start-Sleep -Second 1
+            $waitEvent2.Set()
+
+            $dataAdded = Wait-Event -SourceIdentifier PSDetourAdded -Timeout 5
+            if (-not $dataAdded) {
+                throw "timeout waiting for trace output"
+            }
+            $actual = $outputStream[$dataAdded.SourceEventArgs[0].Index]
+
+            $ps.Stop()
+            try {
+                $ps.EndInvoke($task)
+            }
+            catch [System.Management.Automation.PipelineStoppedException] {}
+
+        }
+        finally {
+            if ($waitEvent1) {
+                $waitEvent1.Dispose()
+            }
+            if ($waitEvent2) {
+                $waitEvent2.Dispose()
+            }
+            if ($proc) {
+                $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+            }
+            if ($registeredEvent) {
+                Remove-Event -SourceIdentifier PSDetourAdded -ErrorAction SilentlyContinue
+                Unregister-Event -SourceIdentifier PSDetourAdded
+            }
+        }
+
+        $actual | Should -Be 5
+    }
+
+    It "Traces other process with outputs" {
+        $proc = $waitEvent1 = $waitEvent2 = $null
+        $registeredEvent = $false
+        $eventName = [Guid]::NewGuid().Guid
+
+        try {
+            $waitEvent1 = [System.Threading.EventWaitHandle]::new(
+                $false,
+                [System.Threading.EventResetMode]::ManualReset,
+                "Global\$eventName-1")
+            $waitEvent2 = [System.Threading.EventWaitHandle]::new(
+                $false,
+                [System.Threading.EventResetMode]::ManualReset,
+                "Global\$eventName-2")
+
+            $procScript = {
+                $ErrorActionPreference = 'Stop'
+
+                $commonPath = 'REPLACE_COMMON_PATH'
+                .$commonPath
+
+                $eventName = 'REPLACE_EVENT_NAME'
+                $waitEvent1 = [System.Threading.EventWaitHandle]::OpenExisting("Global\$eventName-1")
+                $waitEvent2 = [System.Threading.EventWaitHandle]::OpenExisting("Global\$eventName-2")
+                try {
+                    $waitEvent1.Set()
+                    if (-not $waitEvent2.WaitOne(5000)) {
+                        throw "Timed out waiting to start"
+                    }
+                    [PSDetourTest.Native]::Sleep(5)
+                }
+                finally {
+                    $waitEvent1.Dispose()
+                    $waitEvent2.Dispose()
+                }
+
+                "Done"
+                Start-Sleep -Seconds 60
+            }.ToString() -replace 'REPLACE_EVENT_NAME', $eventName -replace 'REPLACE_COMMON_PATH', ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+            $encCommand = [System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($procScript))
+
+            $procParams = @{
+                FilePath = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+                ArgumentList = "-NoProfile -EncodedCommand $encCommand"
+                PassThru = $true
+                WindowStyle = 'Hidden'
+            }
+            $proc = Start-Process @procParams
+
+            $hook = New-PSDetourHook -DllName Kernel32.dll -MethodName Sleep -Action {
+                param([int]$Milliseconds)
+
+                $this.State.WriteDebug("debug")
+                $this.State.WriteError([System.Management.Automation.ErrorRecord]::new(
+                    [System.Exception]"Exception",
+                    "ErrorId",
+                    "NotSpecified",
+                    $null
+                ))
+                $this.State.WriteInformation([System.Management.Automation.InformationRecord]::new(
+                    "object",
+                    "source"
+                ))
+                $this.State.WriteProgress([System.Management.Automation.ProgressRecord]::new(
+                    1,
+                    "activity",
+                    "description"
+                ))
+                $this.State.WriteVerbose("verbose")
+                $this.State.WriteWarning("warning")
+                $this.State.WriteLine()
+                $this.State.WriteLine("line")
+                $res1 = $this.State.ReadLine()
+                $this.State.WriteLine($res1)
+                $res2 = $this.State.ReadLine("readline prompt")
+                $this.State.WriteLine($res2)
+                $this.State.WriteObject($Milliseconds)
+            }
+
+            $modulePath = Join-Path (Get-Module -Name PSDetour).ModuleBase 'PSDetour.psd1'
+
+            $ps = [PowerShell]::Create()
+            $null = $ps.AddScript({
+                param($ModulePath, $Hook, $Process)
+
+                Import-Module $ModulePath -ErrorAction Stop
+
+                "started"
+                $Hook | Trace-PSDetourProcess -ProcessId $Process -Debug -Verbose -WarningAction Continue
+            }).AddParameters(@{ModulePath = $modulePath; Hook = $hook; Process = $proc})
+
+            $inputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+            $outputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+            Register-ObjectEvent -InputObject $outputStream -EventName DataAdded -SourceIdentifier PSDetourAdded
+            $registeredEvent = $true
+
+            $customHost = [PSDetourTest.Host]::new($Host)
+            $psi = [System.Management.Automation.PSInvocationSettings]@{
+                Host = $customHost
+            }
+
+            if (-not $waitEvent1.WaitOne(5000)) {
+                throw "timed out waiting for child process to be ready"
+            }
+            $task = $ps.BeginInvoke($inputStream, $outputStream, $psi, $null, $null)
+
+            # Waits until started has been written
+            Wait-Event -SourceIdentifier PSDetourAdded | Remove-Event
+
+            # Add a second padding for the trace to actually start
+            Start-Sleep -Second 1
+            $waitEvent2.Set()
+
+            $dataAdded = Wait-Event -SourceIdentifier PSDetourAdded -Timeout 5
+            if (-not $dataAdded) {
+                throw "timeout waiting for trace output"
+            }
+            $actual = $outputStream[$dataAdded.SourceEventArgs[0].Index]
+
+            $ps.Stop()
+            try {
+                $ps.EndInvoke($task)
+            }
+            catch [System.Management.Automation.PipelineStoppedException] {}
+
+        }
+        finally {
+            if ($waitEvent1) {
+                $waitEvent1.Dispose()
+            }
+            if ($waitEvent2) {
+                $waitEvent2.Dispose()
+            }
+            if ($proc) {
+                $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+            }
+            if ($registeredEvent) {
+                Remove-Event -SourceIdentifier PSDetourAdded -ErrorAction SilentlyContinue
+                Unregister-Event -SourceIdentifier PSDetourAdded
+            }
+        }
+
+        $actual | Should -Be 5
+        $ps.Streams.Error.Count | Should -Be 1
+        $ps.Streams.Error[0].ToString() | Should -Be Exception
+        $ps.Streams.Progress.Count | Should -Be 1
+        $ps.Streams.Progress[0].ActivityId | Should -Be 1
+        $ps.Streams.Progress[0].Activity | Should -Be activity
+        $ps.Streams.Progress[0].StatusDescription | Should -Be description
+        $ps.Streams.Verbose.Count | Should -Be 1
+        $ps.Streams.Verbose[0].ToString() | Should -Be verbose
+        $ps.Streams.Debug.Count | Should -Be 1
+        $ps.Streams.Debug[0].ToString() | Should -Be debug
+        $ps.Streams.Warning.Count | Should -Be 1
+        $ps.Streams.Warning[0].ToString() | Should -Be warning
+        $ps.Streams.Information.Count | Should -Be 1
+        $ps.Streams.Information[0].MessageData | Should -Be object
+        $ps.Streams.Information[0].Source | Should -Be source
+
+        $customHost.UI.WriteCalls.WriteLine.Count | Should -Be 5
+        $customHost.UI.WriteCalls.WriteLine[0] | Should -Be ''
+        $customHost.UI.WriteCalls.WriteLine[1] | Should -Be line
+        $customHost.UI.WriteCalls.WriteLine[2] | Should -Be 'readline response'
+        $customHost.UI.WriteCalls.WriteLine[3] | Should -Be 'readline prompt'
+        $customHost.UI.WriteCalls.WriteLine[4] | Should -Be 'readline response'
+    }
+
+    It "Traces other process that has ended" {
+        $proc = $waitEvent1 = $waitEvent2 = $null
+        $registeredEvent = $false
+        $eventName = [Guid]::NewGuid().Guid
+
+        try {
+            $waitEvent1 = [System.Threading.EventWaitHandle]::new(
+                $false,
+                [System.Threading.EventResetMode]::ManualReset,
+                "Global\$eventName-1")
+            $waitEvent2 = [System.Threading.EventWaitHandle]::new(
+                $false,
+                [System.Threading.EventResetMode]::ManualReset,
+                "Global\$eventName-2")
+
+            $procScript = {
+                $ErrorActionPreference = 'Stop'
+
+                $commonPath = 'REPLACE_COMMON_PATH'
+                .$commonPath
+
+                $eventName = 'REPLACE_EVENT_NAME'
+                $waitEvent1 = [System.Threading.EventWaitHandle]::OpenExisting("Global\$eventName-1")
+                $waitEvent2 = [System.Threading.EventWaitHandle]::OpenExisting("Global\$eventName-2")
+                try {
+                    $waitEvent1.Set()
+                    if (-not $waitEvent2.WaitOne(5000)) {
+                        throw "Timed out waiting to start"
+                    }
+                    [PSDetourTest.Native]::Sleep(5)
+                }
+                finally {
+                    $waitEvent1.Dispose()
+                    $waitEvent2.Dispose()
+                }
+            }.ToString() -replace 'REPLACE_EVENT_NAME', $eventName -replace 'REPLACE_COMMON_PATH', ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+            $encCommand = [System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($procScript))
+
+            $procParams = @{
+                FilePath = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+                ArgumentList = "-NoProfile -NonInteractive -EncodedCommand $encCommand"
+                PassThru = $true
+                WindowStyle = 'Hidden'
+            }
+            $proc = Start-Process @procParams
+
+            $hook = New-PSDetourHook -DllName Kernel32.dll -MethodName Sleep -Action {
+                param([int]$Milliseconds)
+
+                $this.State.WriteObject($Milliseconds)
+            }
+
+            $modulePath = Join-Path (Get-Module -Name PSDetour).ModuleBase 'PSDetour.psd1'
+
+            $ps = [PowerShell]::Create()
+            $null = $ps.AddScript({
+                param($ModulePath, $Hook, $Process)
+
+                Import-Module $ModulePath -ErrorAction Stop
+
+                "started"
+                $Hook | Trace-PSDetourProcess -ProcessId $Process
+            }).AddParameters(@{ModulePath = $modulePath; Hook = $hook; Process = $proc})
+
+            $inputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+            $outputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+            Register-ObjectEvent -InputObject $outputStream -EventName DataAdded -SourceIdentifier PSDetourAdded
+            $registeredEvent = $true
+            $psi = [System.Management.Automation.PSInvocationSettings]@{
+                Host = $host
+            }
+
+            if (-not $waitEvent1.WaitOne(5000)) {
+                throw "timed out waiting for child process to be ready"
+            }
+            $task = $ps.BeginInvoke($inputStream, $outputStream, $psi, $null, $null)
+
+            # Waits until started has been written
+            Wait-Event -SourceIdentifier PSDetourAdded | Remove-Event
+
+            # Add a second padding for the trace to actually start
+            Start-Sleep -Second 1
+            $waitEvent2.Set()
+
+            $dataAdded = Wait-Event -SourceIdentifier PSDetourAdded -Timeout 5
+            if (-not $dataAdded) {
+                throw "timeout waiting for trace output"
+            }
+            $actual = $outputStream[$dataAdded.SourceEventArgs[0].Index]
+
+            $ps.EndInvoke($task)
+        }
+        finally {
+            if ($waitEvent1) {
+                $waitEvent1.Dispose()
+            }
+            if ($waitEvent2) {
+                $waitEvent2.Dispose()
+            }
+            if ($proc) {
+                $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+            }
+            if ($registeredEvent) {
+                Remove-Event -SourceIdentifier PSDetourAdded -ErrorAction SilentlyContinue
+                Unregister-Event -SourceIdentifier PSDetourAdded
+            }
+        }
+
+        $actual | Should -Be 5
+    }
+
+    It "Stops trace" {
+        $hook = New-PSDetourHook -DllName Kernel32.dll -MethodName Sleep -Action {
+            param([int]$Milliseconds)
+
+            $this.State.WriteObject($Milliseconds)
+            $this.State.StopTrace()
+        }
+
+        $modulePath = Join-Path (Get-Module -Name PSDetour).ModuleBase 'PSDetour.psd1'
+
+        $ps = [PowerShell]::Create()
+        $null = $ps.AddScript({
+            param($ModulePath, $Hook)
+
+            Import-Module $ModulePath -ErrorAction Stop
+
+            "started"
+            $Hook | Trace-PSDetourProcess
+        }).AddParameters(@{ModulePath = $modulePath; Hook = $hook})
+
+        $inputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $outputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $null = Register-ObjectEvent -InputObject $outputStream -EventName DataAdded -SourceIdentifier PSDetourAdded
+        try {
+            $psi = [System.Management.Automation.PSInvocationSettings]@{
+                Host = $host
+            }
+            $task = $ps.BeginInvoke($inputStream, $outputStream, $psi, $null, $null)
+
+            # Waits until started has been written
+            Wait-Event -SourceIdentifier PSDetourAdded | Remove-Event
+
+            # Add a second padding for the trace to actually start
+            Start-Sleep -Second 1
+            [PSDetourTest.Native]::Sleep(5)
+
+            $dataAdded = Wait-Event -SourceIdentifier PSDetourAdded -Timeout 5
+            if (-not $dataAdded) {
+                throw "timeout waiting for trace output"
+            }
+            $actual = $outputStream[$dataAdded.SourceEventArgs[0].Index]
+
+            $ps.EndInvoke($task)
+        }
+        finally {
+            Remove-Event -SourceIdentifier PSDetourAdded -ErrorAction SilentlyContinue
+            Unregister-Event -SourceIdentifier PSDetourAdded
+        }
+
+        $actual | Should -Be 5
+    }
+
+    It "Shares functions" {
+        $hook = New-PSDetourHook -DllName Kernel32.dll -MethodName Sleep -Action {
+            param([int]$Milliseconds)
+
+            Set-Item -Path Function:Test-Function -Value $this.State.GetFunction("Test-Function")
+            $this.State.WriteObject((Test-Function))
+        }
+
+        $modulePath = Join-Path (Get-Module -Name PSDetour).ModuleBase 'PSDetour.psd1'
+
+        $ps = [PowerShell]::Create()
+        $null = $ps.AddScript({
+            param($ModulePath, $Hook)
+
+            Import-Module $ModulePath -ErrorAction Stop
+
+            "started"
+            $Hook | Trace-PSDetourProcess -FunctionsToDefine @{
+                'Test-Function' = {1}
+            }
+        }).AddParameters(@{ModulePath = $modulePath; Hook = $hook})
+
+        $inputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $outputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $null = Register-ObjectEvent -InputObject $outputStream -EventName DataAdded -SourceIdentifier PSDetourAdded
+        try {
+            $psi = [System.Management.Automation.PSInvocationSettings]@{
+                Host = $host
+            }
+            $task = $ps.BeginInvoke($inputStream, $outputStream, $psi, $null, $null)
+
+            # Waits until started has been written
+            Wait-Event -SourceIdentifier PSDetourAdded | Remove-Event
+
+            # Add a second padding for the trace to actually start
+            Start-Sleep -Second 1
+            [PSDetourTest.Native]::Sleep(5)
+
+            $dataAdded = Wait-Event -SourceIdentifier PSDetourAdded -Timeout 5
+            if (-not $dataAdded) {
+                throw "timeout waiting for trace output"
+            }
+            $actual = $outputStream[$dataAdded.SourceEventArgs[0].Index]
+
+            $ps.Stop()
+            try {
+                $ps.EndInvoke($task)
+            }
+            catch [System.Management.Automation.PipelineStoppedException] {}
+        }
+        finally {
+            Remove-Event -SourceIdentifier PSDetourAdded -ErrorAction SilentlyContinue
+            Unregister-Event -SourceIdentifier PSDetourAdded
+        }
+
+        $actual | Should -Be 1
+    }
+
+    It "Hooks with address <Scenario>" -TestCases @(
+        @{Scenario = 'Absolute'}
+        @{Scenario = 'Relative'}
+    ) {
+        param($Scenario)
+
+        $k32 = [System.Runtime.InteropServices.NativeLibrary]::Load("Kernel32.dll")
+        $sleepAddr = [System.Runtime.InteropServices.NativeLibrary]::GetExport($k32, "Sleep")
+        $hookParams = @{}
+        if ($Scenario -eq 'Absolute') {
+            $hookParams.Address = $sleepAddr
+        }
+        else {
+            $hookParams.Address = [IntPtr]($sleepAddr.ToInt64() - $k32.ToInt64())
+            $hookParams.AddressIsOffset = $true
+        }
+
+        $hook = New-PSDetourHook -DllName Kernel32.dll -MethodName Sleep -Action {
+            param([int]$Milliseconds)
+
+            $this.State.WriteObject($Milliseconds)
+        }
+
+        $modulePath = Join-Path (Get-Module -Name PSDetour).ModuleBase 'PSDetour.psd1'
+
+        $ps = [PowerShell]::Create()
+        $null = $ps.AddScript({
+            param($ModulePath, $Hook)
+
+            Import-Module $ModulePath -ErrorAction Stop
+
+            "started"
+            $Hook | Trace-PSDetourProcess
+        }).AddParameters(@{ModulePath = $modulePath; Hook = $hook})
+
+        $inputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $outputStream = [System.Management.Automation.PSDataCollection[object]]::new()
+        $null = Register-ObjectEvent -InputObject $outputStream -EventName DataAdded -SourceIdentifier PSDetourAdded
+        try {
+            $psi = [System.Management.Automation.PSInvocationSettings]@{
+                Host = $host
+            }
+            $task = $ps.BeginInvoke($inputStream, $outputStream, $psi, $null, $null)
+
+            # Waits until started has been written
+            Wait-Event -SourceIdentifier PSDetourAdded | Remove-Event
+
+            # Add a second padding for the trace to actually start
+            Start-Sleep -Second 1
+            [PSDetourTest.Native]::Sleep(5)
+
+            $dataAdded = Wait-Event -SourceIdentifier PSDetourAdded -Timeout 5
+            if (-not $dataAdded) {
+                throw "timeout waiting for trace output"
+            }
+            $actual = $outputStream[$dataAdded.SourceEventArgs[0].Index]
+
+            $ps.Stop()
+            try {
+                $ps.EndInvoke($task)
+            }
+            catch [System.Management.Automation.PipelineStoppedException] {}
+        }
+        finally {
+            Remove-Event -SourceIdentifier PSDetourAdded -ErrorAction SilentlyContinue
+            Unregister-Event -SourceIdentifier PSDetourAdded
+        }
+
+        $actual | Should -Be 5
+    }
+}

--- a/tests/common.ps1
+++ b/tests/common.ps1
@@ -7,7 +7,14 @@ if (-not (Get-Module -Name $moduleName -ErrorAction SilentlyContinue)) {
 
 Add-Type -TypeDefinition @'
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Management.Automation.Runspaces;
 using System.Runtime.InteropServices;
+using System.Security;
 
 namespace PSDetourTest
 {
@@ -26,6 +33,12 @@ namespace PSDetourTest
             [MarshalAs(UnmanagedType.LPWStr)] string lpTargetFileName,
             int dwFlags);
 
+        [DllImport("Kernel32.dll")]
+        public static extern IntPtr OpenProcess(
+            int dwDesiredAccess,
+            bool bInheritHandle,
+            int dwProcessId);
+
         [DllImport("Advapi32.dll")]
         public static extern bool OpenProcessToken(
             IntPtr hProcess,
@@ -34,6 +47,168 @@ namespace PSDetourTest
 
         [DllImport("Kernel32.dll")]
         public static extern void Sleep(int dwMilliSeconds);
+    }
+
+    public class Host : PSHost, IHostSupportsInteractiveSession
+    {
+        private readonly PSHost PSHost;
+        private readonly HostUI HostUI;
+
+        public Host(PSHost host){
+            PSHost=host;
+            HostUI = new HostUI(PSHost.UI);
+        }
+
+        public override CultureInfo CurrentCulture => PSHost.CurrentCulture;
+
+        public override CultureInfo CurrentUICulture => PSHost.CurrentUICulture;
+
+        public override Guid InstanceId => PSHost.InstanceId;
+
+        public override string Name => PSHost.Name;
+
+        public override PSHostUserInterface UI => HostUI;
+
+        public override Version Version => PSHost.Version;
+
+        public override void EnterNestedPrompt()
+        {
+            PSHost.EnterNestedPrompt();
+        }
+
+        public override void ExitNestedPrompt()
+        {
+            PSHost.ExitNestedPrompt();
+        }
+
+        public override void NotifyBeginApplication()
+        {
+            PSHost.NotifyBeginApplication();
+        }
+
+        public override void NotifyEndApplication()
+        {
+            PSHost.NotifyEndApplication();
+        }
+
+        public override void SetShouldExit(int exitCode)
+        {
+            PSHost.SetShouldExit(exitCode);
+        }
+
+        public void PushRunspace(Runspace runspace)
+        {
+            ((IHostSupportsInteractiveSession)PSHost).PushRunspace(runspace);
+        }
+
+        public void PopRunspace()
+        {
+            ((IHostSupportsInteractiveSession)PSHost).PopRunspace();
+        }
+
+        public bool IsRunspacePushed => ((IHostSupportsInteractiveSession)PSHost).IsRunspacePushed;
+
+        public Runspace Runspace => ((IHostSupportsInteractiveSession)PSHost).Runspace;
+    }
+
+    public class HostUI : PSHostUserInterface, IHostUISupportsMultipleChoiceSelection
+    {
+        private readonly PSHostUserInterface PSHostUI;
+
+        public readonly Dictionary<string, List<string>> WriteCalls = new Dictionary<string, List<string>>();
+
+        public HostUI(PSHostUserInterface psHostUI)
+        {
+            PSHostUI = psHostUI;
+            WriteCalls["Debug"] = new List<string>();
+            WriteCalls["Error"] = new List<string>();
+            WriteCalls["Progress"] = new List<string>();
+            WriteCalls["Verbose"] = new List<string>();
+            WriteCalls["Warning"] = new List<string>();
+            WriteCalls["Write"] = new List<string>();
+            WriteCalls["WriteLine"] = new List<string>();
+        }
+
+        public override PSHostRawUserInterface RawUI => PSHostUI.RawUI;
+
+        public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions)
+        {
+            return PSHostUI.Prompt(caption, message, descriptions);
+        }
+
+        public override int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice)
+        {
+            return PSHostUI.PromptForChoice(caption, message, choices, defaultChoice);
+        }
+
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        {
+            return PSHostUI.PromptForCredential(caption, message, userName, targetName, allowedCredentialTypes, options);
+        }
+
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+        {
+            return PSHostUI.PromptForCredential(caption, message, userName, targetName);
+        }
+
+        public override string ReadLine()
+        {
+            return "readline response";
+        }
+
+        public override SecureString ReadLineAsSecureString()
+        {
+            return PSHostUI.ReadLineAsSecureString();
+        }
+
+        public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
+        {
+            WriteCalls["Write"].Add(value);
+        }
+
+        public override void Write(string value)
+        {
+            WriteCalls["Write"].Add(value);
+        }
+
+        public override void WriteDebugLine(string message)
+        {
+            WriteCalls["Debug"].Add(message);
+        }
+
+        public override void WriteErrorLine(string value)
+        {
+            WriteCalls["Error"].Add(value);
+        }
+
+        public override void WriteLine(string value)
+        {
+            WriteCalls["WriteLine"].Add(value);
+        }
+
+        public override void WriteProgress(long sourceId, ProgressRecord record)
+        {
+            WriteCalls["Progress"].Add(record.ToString());
+        }
+
+        public override void WriteVerboseLine(string message)
+        {
+            WriteCalls["Verbose"].Add(message);
+        }
+
+        public override void WriteWarningLine(string message)
+        {
+            WriteCalls["Warning"].Add(message);
+        }
+
+        public Collection<int> PromptForChoice(string caption,
+            string message,
+            Collection<ChoiceDescription> choices,
+            IEnumerable<int> defaultChoices)
+        {
+            return ((IHostUISupportsMultipleChoiceSelection)PSHostUI).PromptForChoice(
+                caption, message, choices, defaultChoices);
+        }
     }
 }
 '@


### PR DESCRIPTION
Adds the Trace-PSDetourProcess that makes it easier to trace API calls in other processes. It provides a common logging and basic breakpoint/read setup.

Also adds support for DetouredModules in the `$this` context that allows a hook to access other hooks original methods.