### PR TITLE
Improve trace command helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for PSDetour
 
+## v0.4.0 - TBD
+
+* Automatically define `-FunctionsToDefine` in the hooks being run with `Trace-PSDetourProcess`, no need to call `$this.State.GetFunction('Name')` to redefine it
+  * `$this.State.GetFunction` has been removed and will no longer work
+* Ensure the scriptblocks used with `Trace-PSDetourProcess` keep the original stacktrace locations for better debugging
+
 ## v0.3.1 - 2023-07-25
 
 * Added lock for `Trace-PSDetourProcess` output pipe to avoid multiple threads clobbering the serialized output

--- a/docs/en-US/Trace-PSDetourProcess.md
+++ b/docs/en-US/Trace-PSDetourProcess.md
@@ -14,7 +14,7 @@ Starts a PSDetour hook in either the current process or specified process and pr
 
 ```
 Trace-PSDetourProcess [-Hook] <DetourHook[]> [-ProcessId <ProcessIntString>] [-FunctionsToDefine <IDictionary>]
- [<CommonParameters>]
+ [-CSharpToLoad <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -92,7 +92,6 @@ PS C:\> $hook = New-PSDetourHook -DllName Kernel32 -MethodName GetCurrentProcess
 ...     [OutputType([int])]
 ...     param()
 ...
-...     Set-Item -Path Function:My-Function -Value $this.State.GetFunction("My-Function")
 ...     $this.State.WriteObject((My-Function))
 ...
 ...     $this.Invoke()
@@ -100,14 +99,30 @@ PS C:\> $hook = New-PSDetourHook -DllName Kernel32 -MethodName GetCurrentProcess
 PS C:\> $hook | Trace-PSDetourProcess -FunctionsToDefine @{"My-Function" = ${function:My-Function}}
 ```
 
-Registers the function `My-Function` which can be redefined in the hook scope through `$this.State.GetFunction`.
-The function can then be called just like any other PowerShell function.
+Registers the function `My-Function` which will be redefined in the hook scope when run so can be run like normal.
 
 ## PARAMETERS
 
+### -CSharpToLoad
+C# code that is loaded into the process before the hooks are run.
+Use this to pre-load any C# code that needs to be compiled so that the hooks can access the classes in the definitions.
+As a C# assembly cannot be unloaded, the only way to update the C# code being used if changed is to restart the target process.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: CSharp
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -FunctionsToDefine
-Common functions to define that the `$this.State` will have access to in the hook.
-These function scriptblocks can be access through `$this.State.GetFunction("Function-Name").
+Common functions to define in the running hook.
+These functions will automatically be redefined in the traced session and can be invoked like normal.
 
 ```yaml
 Type: IDictionary

--- a/docs/en-US/about_PSDetourSessions.md
+++ b/docs/en-US/about_PSDetourSessions.md
@@ -76,9 +76,6 @@ Trace-PSDetourProcess -ProcessId $otherProc -Hooks $hooks
 To stop a trace, press `ctrl+c`, or ensure one of your hooks sends the `StopTrace` signal.
 The `State` object set by `Trace-PSDetourProcess` has the following methods:
 
-* `GetFunction(string function)`
-    * Gets the function scriptblock of the function name specified
-    * These functions are populated by the `-FunctionsToDefine` parameter
 * `WriteDebug(string text)`
     * Writes a debug record
 * `WriteError(ErrorRecord errorRecord)`

--- a/module/PSDetour.psd1
+++ b/module/PSDetour.psd1
@@ -14,7 +14,7 @@
     RootModule        = 'PSDetour.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.3.1'
+    ModuleVersion     = '0.4.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSDetour/AstHelper.cs
+++ b/src/PSDetour/AstHelper.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation.Language;
+
+namespace PSDetour;
+
+internal static class AstHelper
+{
+    private static ScriptExtent _blankExtent = new(new(null, 0, 0, null), new(null, 0, 0, null));
+
+    public static HashtableAst CreateHashtableAst(IDictionary<string, object?> value)
+    {
+        return new(
+            _blankExtent,
+            value.Select(kvp => CreateKeyValuePairAst(kvp))
+        );
+    }
+
+    public static Tuple<ExpressionAst, StatementAst> CreateKeyValuePairAst(KeyValuePair<string, object?> kvp)
+    {
+        return new(
+            new StringConstantExpressionAst(_blankExtent, kvp.Key, StringConstantType.BareWord),
+            CreateSingleExpressionPipeline(kvp.Value)
+        );
+    }
+
+    public static PipelineAst CreateSingleExpressionPipeline(object? value)
+    {
+        ExpressionAst exp;
+        if (value == null)
+        {
+            exp = new VariableExpressionAst(_blankExtent, "null", false);
+        }
+        else if (value is int)
+        {
+            exp = new ConstantExpressionAst(_blankExtent, value);
+        }
+        else if (value is IDictionary<string, object?> dict)
+        {
+            exp = CreateHashtableAst(dict);
+        }
+        else
+        {
+            exp = new StringConstantExpressionAst(
+                _blankExtent,
+                value.ToString() ?? "",
+                StringConstantType.SingleQuoted);
+        }
+
+        return new(
+            _blankExtent,
+            new CommandBaseAst[]
+            {
+                new CommandExpressionAst(
+                    _blankExtent,
+                    exp,
+                    null
+                )
+            }
+        );
+    }
+
+    public static ScriptBlockAst CreateScriptBlockWithInjectedFunctions(
+        string mainFunctionName,
+        string paramBlock,
+        IEnumerable<Dictionary<string, object?>> functions
+    )
+    {
+        /*
+        # Defines the functions needed for the hook
+        @(
+            ... # All functions to define
+            @{
+                Name = "$DllName!$MethodName'
+                Value = 'hook script'
+                Path = $null  # Or the path to the hook script
+                Line = 0
+            }
+        )
+        */
+        ArrayExpressionAst functionsArray = new(
+            _blankExtent,
+            new(
+                _blankExtent,
+                functions.Select(f => AstHelper.CreateSingleExpressionPipeline(f)),
+                null
+            )
+        );
+
+        /*
+        # Enumerates the functions and defines them inline with the correct
+        # script and script line positions.
+        @(...) | ForEach-Object {
+            . ([System.Management.Automation.Language.Parser]::ParseInput(
+                "$([string]::new("`n", $_.Line))Function $($_.Name) {$($_.Content)}",
+                $_.File,
+                [ref]$null,
+                [ref]$null
+            )).GetScriptBlock()
+        }
+        */
+
+        InvokeMemberExpressionAst parseInput = new(
+            _blankExtent,
+            new TypeExpressionAst(
+                _blankExtent,
+                new TypeName(_blankExtent, typeof(Parser).FullName)
+            ),
+            new StringConstantExpressionAst(_blankExtent, "ParseInput", StringConstantType.BareWord),
+            new ExpressionAst[]
+            {
+                new ExpandableStringExpressionAst(
+                    _blankExtent,
+                    "$([string]::new(\"`n\", $_.Line))Function $($_.Name) {$($_.Value)}",
+                    StringConstantType.DoubleQuoted
+                ),
+                new MemberExpressionAst(
+                    _blankExtent,
+                    new VariableExpressionAst(_blankExtent, "_", false),
+                    new StringConstantExpressionAst(_blankExtent, "Path", StringConstantType.BareWord),
+                    false
+                ),
+                new ConvertExpressionAst(
+                    _blankExtent,
+                    new TypeConstraintAst(
+                        _blankExtent,
+                        new TypeName(_blankExtent, "ref")
+                    ),
+                    new VariableExpressionAst(_blankExtent, "null", false)
+                ),
+                new ConvertExpressionAst(
+                    _blankExtent,
+                    new TypeConstraintAst(
+                        _blankExtent,
+                        new TypeName(_blankExtent, "ref")
+                    ),
+                    new VariableExpressionAst(_blankExtent, "null", false)
+                )
+            },
+            true,
+            false
+        );
+        InvokeMemberExpressionAst getScriptBlock = new(
+            _blankExtent,
+            new ParenExpressionAst(
+                _blankExtent,
+                new PipelineAst(
+                    _blankExtent,
+                    new CommandBaseAst[]
+                    {
+                        new CommandExpressionAst(
+                            _blankExtent,
+                            parseInput,
+                            null
+                        )
+                    },
+                    false
+                )
+            ),
+            new StringConstantExpressionAst(_blankExtent, "GetScriptBlock", StringConstantType.BareWord),
+            null,
+            false,
+            false
+        );
+
+        ScriptBlockAst foreachProcess = new(
+            _blankExtent,
+            null,
+            null,
+            null,
+            new StatementBlockAst(
+                _blankExtent,
+                new StatementAst[]
+                {
+                    new PipelineAst(
+                        _blankExtent,
+                        new CommandAst(
+                            _blankExtent,
+                            new CommandElementAst[]
+                            {
+                                getScriptBlock
+                            },
+                            TokenKind.Dot,
+                            null
+                        ),
+                        false
+                    )
+                },
+                null
+            ),
+            false,
+            false
+        );
+
+        PipelineAst funcDef = new(
+            _blankExtent,
+            new CommandBaseAst[]
+            {
+                new CommandExpressionAst(
+                    _blankExtent,
+                    functionsArray,
+                    null
+                ),
+                new CommandAst(
+                    _blankExtent,
+                    new CommandElementAst[]
+                    {
+                        new StringConstantExpressionAst(_blankExtent, "ForEach-Object", StringConstantType.BareWord),
+                        new ScriptBlockExpressionAst(_blankExtent, foreachProcess)
+                    },
+                    TokenKind.Unknown,
+                    null
+                )
+            },
+            false
+        );
+
+        /*
+        MainFunction @PSBoundParameters
+        */
+        PipelineAst invokeMain = new(
+            _blankExtent,
+            new CommandBaseAst[]
+            {
+                new CommandAst(
+                    _blankExtent,
+                    new CommandElementAst[]
+                    {
+                        new StringConstantExpressionAst(_blankExtent, mainFunctionName, StringConstantType.BareWord),
+                        new VariableExpressionAst(_blankExtent, "PSBoundParameters", true)
+                    },
+                    TokenKind.Unknown,
+                    null
+                )
+            },
+            false
+        );
+
+        // We need to re-parse the param block so the stub scriptblock
+        // signature matches the hooks version.
+        ScriptBlockAst paramAst = Parser.ParseInput(paramBlock, out var _1, out var _2);
+
+        ScriptBlockAst sbkAst = new(
+            _blankExtent,
+            null, // using statements
+            (ParamBlockAst?)paramAst.ParamBlock?.Copy(),
+            new StatementBlockAst(
+                _blankExtent,
+                new StatementAst[]
+                {
+                    funcDef,
+                    invokeMain
+                },
+                null
+            ),
+            false
+        );
+        return sbkAst;
+    }
+}

--- a/src/PSDetour/Commands/PSDetourSession.cs
+++ b/src/PSDetour/Commands/PSDetourSession.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Threading;

--- a/src/PSDetour/FunctionDefinitionAstExtensions.cs
+++ b/src/PSDetour/FunctionDefinitionAstExtensions.cs
@@ -1,0 +1,12 @@
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace PSDetour;
+
+public static class FunctionDefinitionAstExtension
+{
+    // GetScriptBlock isn't defined on this type like ScriptBlockAst.
+    // This uses reflection to achieve the same thing that pwsh does internally.
+    public static ScriptBlock GetScriptBlock(this FunctionDefinitionAst funcAst)
+        => (ScriptBlock)ReflectionInfo.SbkAstCtor.Invoke(new object[] { funcAst, funcAst.IsFilter });
+}

--- a/src/PSDetour/Reflection.cs
+++ b/src/PSDetour/Reflection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Host;
+using System.Management.Automation.Language;
 using System.Management.Automation.Remoting;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -14,6 +15,7 @@ internal static class ReflectionInfo
 {
     private static ModuleBuilder? _builder = null;
     private static ConstructorInfo? _marshalAsCtor = null;
+    private static ConstructorInfo? _sbkAstCtor = null;
     private static ConstructorInfo? _sbkInvokeContextCtor = null;
     private static FieldInfo? _ipcNamedPipeServerEnabledField = null;
     private static MethodInfo? _addrOfPinnedObjFunc = null;
@@ -66,6 +68,26 @@ internal static class ReflectionInfo
             }
 
             return _marshalAsCtor;
+        }
+    }
+
+    public static ConstructorInfo SbkAstCtor
+    {
+        get
+        {
+            if (_sbkAstCtor == null)
+            {
+                Type paramMetaProviderType = typeof(FunctionDefinitionAst).Assembly.GetType(
+                    "System.Management.Automation.Language.IParameterMetadataProvider")!;
+                _sbkAstCtor = typeof(ScriptBlock).GetConstructor(
+                    BindingFlags.NonPublic | BindingFlags.Instance,
+                    new[] {
+                        paramMetaProviderType,
+                        typeof(bool)
+                    })!;
+            }
+
+            return _sbkAstCtor;
         }
     }
 

--- a/tests/common.ps1
+++ b/tests/common.ps1
@@ -15,6 +15,8 @@ using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
 using System.Runtime.InteropServices;
 using System.Security;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PSDetourTest
 {
@@ -47,6 +49,20 @@ namespace PSDetourTest
 
         [DllImport("Kernel32.dll")]
         public static extern void Sleep(int dwMilliSeconds);
+    }
+
+    public static class TestHelpers
+    {
+        public static Task Sleep(int milliseconds, EventWaitHandle waitHandle)
+        {
+            return Task.Run(() => SleepInAnotherThread(milliseconds, waitHandle));
+        }
+
+        private static void SleepInAnotherThread(int milliseconds, EventWaitHandle waitHandle)
+        {
+            waitHandle.WaitOne();
+            Native.Sleep(milliseconds);
+        }
     }
 
     public class Host : PSHost, IHostSupportsInteractiveSession


### PR DESCRIPTION
Improves Trace-PSDetourProcess to automatically define the -FunctionsToDefine inside the running hooks rather than having the hook redefine it themselves. Also ensures the hook scriptblocks are setup with the same position, function name, and script path so that exceptions are easier to track down.